### PR TITLE
README.md: Fix inverted markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ which presents problems for Yosys and/or GHDL.
 
 ## System prepare (Debian based distributions and probably others GNU/Linux systems)
 
-* Install Yosys following [https://github.com/YosysHQ/yosys#setup](this) instructions.
-* Install PyFPGA following [https://gitlab.com/rodrigomelo9/pyfpga#installation](this) instructions.
+* Install Yosys following [these](https://github.com/YosysHQ/yosys#setup) instructions.
+* Install PyFPGA following [these](https://gitlab.com/rodrigomelo9/pyfpga#installation) instructions.
 * Install iverilog and verilator.
-* Install Docker following [https://docs.docker.com/install](this) instructions (to use GHDL).
+* Install Docker following [these](https://docs.docker.com/install) instructions (to use GHDL).
 * To run ISE: `export PATH=<ISE_ROOT_PATH>/ISE/bin/lin64:$PATH`
 * To run Vivado: `export PATH=<VIVADO_ROOT_PATH>/bin:$PATH`
 


### PR DESCRIPTION
The links were pointing to the word "this"